### PR TITLE
Remove Robot and Dashboard from homepage apps section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,16 +16,6 @@ const APPS = [
     to: '/sesh-stats',
     newTab: true,
   },
-  {
-    title: 'Robot',
-    description: 'Interactive robot character.',
-    to: '/robot',
-  },
-  {
-    title: 'Dashboard',
-    description: 'Live data dashboard built with computer vision and sensor integrations.',
-    to: '/dashboard',
-  },
 ]
 
 const cardInner = (title, description) => (


### PR DESCRIPTION
## Summary
- Remove Robot and Dashboard cards from the apps section on the homepage
- Craps Sim and Sesh Stats remain

🤖 Generated with [Claude Code](https://claude.ai/claude-code)