### PR TITLE
Add all-time net tally to craps session history

### DIFF
--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -444,6 +444,22 @@ export default function CrapsSession() {
                     );
                   })}
                 </tbody>
+                <tfoot>
+                  {(() => {
+                    const total = history.reduce((sum, s) => sum + s.netResult, 0);
+                    const color = total > 0 ? "#6dca6d" : total < 0 ? "#ca6d6d" : "#5a7a5a";
+                    return (
+                      <tr style={{ borderTop: "1px solid rgba(212,175,55,0.25)" }}>
+                        <td colSpan={6} style={{ padding: "10px 10px", fontFamily: "'Cinzel', serif", fontSize: "0.58rem", letterSpacing: "0.18em", color: "#5a8a5a", textTransform: "uppercase" }}>
+                          All-time Total
+                        </td>
+                        <td style={{ padding: "10px 10px", fontFamily: "'Cinzel', serif", fontSize: "0.95rem", fontWeight: 700, color }}>
+                          {total > 0 ? `+$${fmt(total)}` : total < 0 ? `-$${fmt(Math.abs(total))}` : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })()}
+                </tfoot>
               </table>
             </div>
           </div>
@@ -572,22 +588,6 @@ export default function CrapsSession() {
                     return acc;
                   }, [])}
                 </tbody>
-                <tfoot>
-                  {(() => {
-                    const total = filtered.reduce((sum, r) => sum + r.net, 0);
-                    const color = total > 0 ? "#6dca6d" : total < 0 ? "#ca6d6d" : "#5a7a5a";
-                    return (
-                      <tr style={{ borderTop: "1px solid rgba(212,175,55,0.25)" }}>
-                        <td colSpan={6} style={{ padding: "10px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.6rem", letterSpacing: "0.18em", color: "#5a8a5a", textTransform: "uppercase" }}>
-                          Session Total
-                        </td>
-                        <td style={{ padding: "10px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.95rem", fontWeight: 700, color }}>
-                          {total > 0 ? `+$${fmt(total)}` : total < 0 ? `-$${fmt(Math.abs(total))}` : "—"}
-                        </td>
-                      </tr>
-                    );
-                  })()}
-                </tfoot>
               </table>
             </div>
           </div>

--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -572,6 +572,22 @@ export default function CrapsSession() {
                     return acc;
                   }, [])}
                 </tbody>
+                <tfoot>
+                  {(() => {
+                    const total = filtered.reduce((sum, r) => sum + r.net, 0);
+                    const color = total > 0 ? "#6dca6d" : total < 0 ? "#ca6d6d" : "#5a7a5a";
+                    return (
+                      <tr style={{ borderTop: "1px solid rgba(212,175,55,0.25)" }}>
+                        <td colSpan={6} style={{ padding: "10px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.6rem", letterSpacing: "0.18em", color: "#5a8a5a", textTransform: "uppercase" }}>
+                          Session Total
+                        </td>
+                        <td style={{ padding: "10px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.95rem", fontWeight: 700, color }}>
+                          {total > 0 ? `+$${fmt(total)}` : total < 0 ? `-$${fmt(Math.abs(total))}` : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })()}
+                </tfoot>
               </table>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds an "All-time Total" footer row to the session history table
- Sums net result across all sessions played in the current browser session
- Color coded green/red for positive/negative

## Test plan
- [ ] Run multiple craps sessions
- [ ] Verify the All-time Total footer updates and reflects the correct cumulative net

🤖 Generated with [Claude Code](https://claude.ai/claude-code)