### PR TITLE
Add interval loop for auto-running sessions

### DIFF
--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -195,7 +195,7 @@ export default function CrapsSession() {
   const [stopAtProfit, setStopAtProfit] = useState(0);
   const [autoRunCount, setAutoRunCount] = useState(1);
   const [historyOpen, setHistoryOpen] = useState(false);
-  const [intervalSecs, setIntervalSecs] = useState(5);
+  const [intervalMs, setIntervalMs] = useState(1000);
   const [maxSessions, setMaxSessions] = useState(100);
   const [running, setRunning] = useState(false);
 
@@ -250,7 +250,7 @@ export default function CrapsSession() {
   const startLoop = () => {
     setRunning(true);
     runLatest.current();
-    intervalRef.current = setInterval(() => runLatest.current(), intervalSecs * 1000);
+    intervalRef.current = setInterval(() => runLatest.current(), intervalMs);
   };
 
   // Clean up interval on unmount
@@ -418,11 +418,11 @@ export default function CrapsSession() {
                 sublabel={autoRunCount === 1 ? "1 session per tick" : `${autoRunCount} sessions per tick`}
               />
               <NumInput
-                label="Every (secs)"
-                value={intervalSecs}
-                onChange={setIntervalSecs}
-                min={1} max={60} step={1}
-                sublabel={`${intervalSecs}s between ticks`}
+                label="Every (ms)"
+                value={intervalMs}
+                onChange={setIntervalMs}
+                min={100} max={60000} step={100}
+                sublabel={`${intervalMs}ms between ticks`}
               />
               <NumInput
                 label="Max Sessions"
@@ -459,7 +459,7 @@ export default function CrapsSession() {
         </div>
         {running && (
           <div style={{ fontFamily: "'Crimson Text', serif", fontSize: "0.88rem", color: "#8ab88a", fontStyle: "italic" }}>
-            {history.length} / {maxSessions} sessions · next tick in {intervalSecs}s
+            {history.length} / {maxSessions} sessions · {intervalMs}ms between ticks
           </div>
         )}
 

--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 
 // Mulberry32 — fast, high-quality 32-bit seeded PRNG
 function mulberry32(seed) {
@@ -195,13 +195,37 @@ export default function CrapsSession() {
   const [stopAtProfit, setStopAtProfit] = useState(0);
   const [autoRunCount, setAutoRunCount] = useState(1);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [intervalSecs, setIntervalSecs] = useState(5);
+  const [maxSessions, setMaxSessions] = useState(100);
+  const [running, setRunning] = useState(false);
+
+  const intervalRef = useRef(null);
+  const sessionCountRef = useRef(0);
+  const runLatest = useRef(null);
+
+  const stopLoop = () => {
+    clearInterval(intervalRef.current);
+    intervalRef.current = null;
+    setRunning(false);
+  };
 
   const run = (replaySeed) => {
     const count = replaySeed ? 1 : autoRunCount;
-    const baseSessionNum = history.length + 1;
+    const currentCount = sessionCountRef.current;
+
+    if (!replaySeed && maxSessions > 0 && currentCount >= maxSessions) {
+      stopLoop();
+      return;
+    }
+
+    const actualCount = (!replaySeed && maxSessions > 0)
+      ? Math.min(count, maxSessions - currentCount)
+      : count;
+
+    const baseSessionNum = currentCount + 1;
     const newEntries = [];
 
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < actualCount; i++) {
       const seed = replaySeed && i === 0 ? replaySeed :
                    i === 0 && seedInput.trim() !== "" ? parseInt(seedInput.trim()) >>> 0 :
                    cryptoSeed();
@@ -212,9 +236,25 @@ export default function CrapsSession() {
     const lastEntry = newEntries[newEntries.length - 1];
     setSession(lastEntry);
     setLastSeed(lastEntry.seed);
-    if (!replaySeed) setHistory(prev => [...prev, ...newEntries]);
+    if (!replaySeed) {
+      setHistory(prev => [...prev, ...newEntries]);
+      sessionCountRef.current += actualCount;
+      if (maxSessions > 0 && sessionCountRef.current >= maxSessions) stopLoop();
+    }
     setView("all");
   };
+
+  // Always keep runLatest pointing at the freshest closure
+  runLatest.current = run;
+
+  const startLoop = () => {
+    setRunning(true);
+    runLatest.current();
+    intervalRef.current = setInterval(() => runLatest.current(), intervalSecs * 1000);
+  };
+
+  // Clean up interval on unmount
+  useEffect(() => () => clearInterval(intervalRef.current), []);
 
   const filtered = session ? (
     view === "all" ? session.rolls :
@@ -369,13 +409,29 @@ export default function CrapsSession() {
           {/* Auto-run sessions */}
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
             <div style={{ fontFamily: "'Cinzel', serif", fontSize: "0.55rem", letterSpacing: "0.25em", color: "#4a7a4a", textTransform: "uppercase", marginBottom: 6 }}>Auto-Run</div>
-            <NumInput
-              label="Sessions"
-              value={autoRunCount}
-              onChange={setAutoRunCount}
-              min={1} max={500} step={1}
-              sublabel={autoRunCount === 1 ? "Single session" : `${autoRunCount} sessions at once`}
-            />
+            <div style={{ display: "flex", gap: 20, flexWrap: "wrap", justifyContent: "center" }}>
+              <NumInput
+                label="Sessions / Tick"
+                value={autoRunCount}
+                onChange={setAutoRunCount}
+                min={1} max={100} step={1}
+                sublabel={autoRunCount === 1 ? "1 session per tick" : `${autoRunCount} sessions per tick`}
+              />
+              <NumInput
+                label="Every (secs)"
+                value={intervalSecs}
+                onChange={setIntervalSecs}
+                min={1} max={60} step={1}
+                sublabel={`${intervalSecs}s between ticks`}
+              />
+              <NumInput
+                label="Max Sessions"
+                value={maxSessions}
+                onChange={setMaxSessions}
+                min={1} max={10000} step={1}
+                sublabel={`Stop at ${maxSessions} total`}
+              />
+            </div>
           </div>
 
         </div>
@@ -383,9 +439,29 @@ export default function CrapsSession() {
 
       {/* Roll button + seed controls */}
       <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 14, paddingBottom: 36 }}>
-        <button className="btn-main" onClick={() => run()}>
-          {autoRunCount > 1 ? `Run ${autoRunCount} Sessions` : session ? "New Session" : "Roll the Bones"}
-        </button>
+        <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap", justifyContent: "center" }}>
+          <button className="btn-main" onClick={() => run()} disabled={running} style={{ opacity: running ? 0.4 : 1 }}>
+            {autoRunCount > 1 ? `Run ${autoRunCount} Sessions` : session ? "New Session" : "Roll the Bones"}
+          </button>
+          <button
+            onClick={running ? stopLoop : startLoop}
+            style={{
+              background: running ? "rgba(202,109,109,0.15)" : "rgba(109,202,109,0.1)",
+              border: `1px solid ${running ? "rgba(202,109,109,0.5)" : "rgba(109,202,109,0.4)"}`,
+              color: running ? "#ca6d6d" : "#6dca6d",
+              fontFamily: "'Cinzel', serif", fontSize: "0.72rem", fontWeight: 700,
+              letterSpacing: "0.12em", padding: "12px 24px", cursor: "pointer",
+              borderRadius: 2, textTransform: "uppercase", transition: "all 0.2s"
+            }}
+          >
+            {running ? "Stop Loop" : "Start Loop"}
+          </button>
+        </div>
+        {running && (
+          <div style={{ fontFamily: "'Crimson Text', serif", fontSize: "0.88rem", color: "#8ab88a", fontStyle: "italic" }}>
+            {history.length} / {maxSessions} sessions · next tick in {intervalSecs}s
+          </div>
+        )}
 
         <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", justifyContent: "center" }}>
           {/* Seed input */}
@@ -549,7 +625,7 @@ export default function CrapsSession() {
                 </div>
               </button>
               <button
-                onClick={() => { setHistory([]); setSession(null); }}
+                onClick={() => { setHistory([]); setSession(null); sessionCountRef.current = 0; stopLoop(); }}
                 style={{ background: "transparent", border: "1px solid rgba(202,109,109,0.3)", color: "#8a5a5a", fontFamily: "'Cinzel', serif", fontSize: "0.55rem", letterSpacing: "0.12em", padding: "4px 10px", cursor: "pointer", borderRadius: 2, textTransform: "uppercase", transition: "all 0.15s", marginRight: 16, flexShrink: 0 }}
                 onMouseEnter={e => { e.currentTarget.style.borderColor = "rgba(202,109,109,0.7)"; e.currentTarget.style.color = "#ca6d6d"; }}
                 onMouseLeave={e => { e.currentTarget.style.borderColor = "rgba(202,109,109,0.3)"; e.currentTarget.style.color = "#8a5a5a"; }}


### PR DESCRIPTION
## Summary
- Start/Stop Loop button runs X sessions every Y milliseconds up to Z total
- Three new config inputs: Sessions/Tick (1–100), Every ms (100–60000ms, default 1000), Max Sessions (1–10000)
- Manual run button disabled while loop is active
- Progress readout shows current / max while running
- Clearing history stops the loop and resets the counter

## Test plan
- [ ] Start loop, verify batches fire on the interval
- [ ] Verify loop auto-stops at max sessions
- [ ] Verify Stop Loop button halts it mid-run
- [ ] Confirm manual run button is disabled during loop
- [ ] Clear history while loop is running — loop stops, counter resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)