### PR TITLE
Craps sim fixes

### DIFF
--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -121,9 +121,8 @@ function simulate({ passBet, odds410, odds59, odds68, seed, buyIn, stopAtProfit 
         passLineBet = 0; oddsBet = 0; point = null; pointsMade++;
       } else if (roll.total === 7) {
         const lost = passLineBet + oddsBet;
-        const preHandBankroll = bankroll + passLineBet + oddsBet;
         const maxExposure = passBet + Math.max(passBet * odds410, passBet * odds59, passBet * odds68);
-        const profitStop = stopAtProfit > 0 && (preHandBankroll - BUY_IN) >= stopAtProfit;
+        const profitStop = stopAtProfit > 0 && (bankroll - BUY_IN) >= stopAtProfit;
         const exposureStop = bankroll < maxExposure;
         const detail = profitStop ? `Seven out — profit target reached`
           : exposureStop ? `Seven out — insufficient funds`

--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -856,12 +856,12 @@ export default function CrapsSession() {
                           {r.detail}
                           {isPeak && <span style={{ marginLeft: 8, fontFamily: "'Cinzel', serif", fontSize: "0.55rem", letterSpacing: "0.15em", color: "#d4af37", verticalAlign: "middle", border: "1px solid rgba(212,175,55,0.5)", padding: "1px 5px", borderRadius: 2 }}>PEAK</span>}
                         </td>
-                        <td style={{ padding: "9px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.92rem", color: r.bankroll >= 500 ? "#c8dfa8" : "#bf8f7f" }}>${fmt(r.bankroll)}</td>
+                        <td style={{ padding: "9px 12px", fontFamily: "'Cinzel', serif", fontSize: "0.92rem", color: r.bankroll >= session.buyIn ? "#c8dfa8" : "#bf8f7f" }}>${fmt(r.bankroll)}</td>
                         <td style={{ padding: "9px 12px", fontFamily: "'Crimson Text', serif", fontSize: "0.95rem",
-                          color: r.net > 0 ? "#6dca6d" : r.net < 0 ? "#ca6d6d" : "#5a7a5a",
-                          fontWeight: r.net !== 0 ? 600 : 400
+                          color: (r.bankroll - session.buyIn) > 0 ? "#6dca6d" : (r.bankroll - session.buyIn) < 0 ? "#ca6d6d" : "#5a7a5a",
+                          fontWeight: r.bankroll !== session.buyIn ? 600 : 400
                         }}>
-                          {r.net > 0 ? `+$${fmt(r.net)}` : r.net < 0 ? `-$${fmt(Math.abs(r.net))}` : "—"}
+                          {(() => { const profit = r.bankroll - session.buyIn; return profit > 0 ? `+$${fmt(profit)}` : profit < 0 ? `-$${fmt(Math.abs(profit))}` : "—"; })()}
                         </td>
                       </tr>
                     );

--- a/src/pages/craps-sim.js
+++ b/src/pages/craps-sim.js
@@ -639,6 +639,7 @@ export default function CrapsSession() {
             <div style={{ display: "flex", alignItems: "center" }}>
               <button
                 onClick={() => setHistoryOpen(o => !o)}
+                aria-label="Toggle session history"
                 style={{ flex: 1, background: "none", border: "none", cursor: "pointer", padding: "16px 16px" }}
               >
                 <div style={{ display: "flex", alignItems: "center", gap: 16 }}>


### PR DESCRIPTION
## Summary
- Net column in roll log now shows cumulative profit (bankroll - buyIn) instead of per-roll win/loss
- Fixed profit stop check to use post-loss bankroll instead of pre-hand bankroll (was triggering early)
- Fixed a11y warning on session history toggle button

## Test plan
- [ ] Verify Net column in roll log reflects cumulative profit from buy-in
- [ ] Verify stop-at-profit only triggers when bankroll after 7-out meets the target